### PR TITLE
Bring on some red-hot hot reload, bashfully

### DIFF
--- a/bin/hotreload.sh
+++ b/bin/hotreload.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# ##################################################
+# Functions to power the poor shite's hot reload :)
+# ##################################################
+# The brainwave to use 'inotify-tools' and 'xdotool' is pinched from
+# https://github.com/traviscross/inotify-refresh
+#
+# Because what could be hotter than hitting f5 for the target tab,
+# in the target browser?
+#
+# If this hot reload is not hot enough, there is Emacs impatient-mode.
+
+
+# "Dev-ing/Drafting" time setup/Teardown scenario:
+#
+# When we first start development (maybe a 'dev_server' function):
+# - xdotool open a new tab in the default browser (say, firefox).
+# - xdotool goto the home page of the shite based on config.
+# - xdotool 'set_window --name' to a UUID for the life of the session.
+# - xdotool close the tab when we kill the dev session
+
+
+# Hot reload scenarios:
+#
+# Refresh current tab when
+# - static asset create, modify, move, delete
+#
+# Go home when
+# - current page deleted
+#
+# Navigate to content when
+# - current page content modified
+# - any content page moved or created or modified
+
+
+__shite_refresh_browser_tab() {
+    local browser_name=${1:-"firefox"}
+    local tab_name=${2:-'*'}
+
+    xdotool search --onlyvisible --name "${tab_name}.*${browser_name}$" \
+            key --clearmodifiers --window %@ 'F5'
+}
+
+__shite_detect_changes() {
+    local dir_path="${1:-.}"
+
+    inotifywait -m -r --exclude '/\.git/|/\.#|/#' \
+                --format '%e %w%f' \
+                -e 'modify,moved_to,moved_from,move,create,delete' \
+                ${dir_path}
+}
+
+__shite_is_reload_page_event() {
+    # truthy/falsey
+    # return the event as-is /when/ it implies reload
+    false
+}
+
+__shite_is_goto_page_event() {
+    # truthy/falsey
+    # return the event as-is /when/ it implies navigate to page
+    false
+}

--- a/bin/hotreload.sh
+++ b/bin/hotreload.sh
@@ -179,13 +179,10 @@ __shite_xdo_cmd_gen() {
 # ##################################################
 
 __shite_xdo_cmd_exec() {
-    local cmd=$(
-        if [[ ${SHITE_DEBUG} == "debug" ]]
-        then "cat"
-        else "xdotool"
-        fi
-          )
-    stdbuf -oL grep -v '^$' | $cmd -
+    if [[ ${SHITE_DEBUG} == "debug" ]]
+    then cat -
+    else stdbuf -oL grep -v '^$' | xdotool -
+    fi
 }
 
 shite_hotreload() {

--- a/bin/hotreload.sh
+++ b/bin/hotreload.sh
@@ -49,13 +49,13 @@ __shite_detect_changes() {
     # Continuously monitor the target directory for file CRUD events
     # Emit a CSV record of UNIX_EPOCH_SECONDS,EVENT_TYPE,DIR_PATH,FILE_NAME
     local watch_dir="$(realpath -e ${1:-$(pwd)})"
-    local watch_events=${2:-'create,modify,delete,moved_to'}
+    local watch_events=${2}
 
     # WATCH A DIRECTORY
     inotifywait -m -r --exclude '/\.git/|/\.#|/#|.*(swp|swx|\~)$' \
                 --timefmt "%s" \
                 --format '%T,%:e,%w,%f' \
-                -e ${watch_events} \
+                $([[ -n ${watch_events} ]] && printf "%s %s" "-e" ${watch_events})  \
                 ${watch_dir} |
         # INCLUDE FILES
         # We have to grep, but a new version of inotifywait has an 'include'
@@ -95,35 +95,77 @@ __shite_xdo_cmd_goto_url() {
 }
 
 __shite_xdo_cmd_gen() {
+    # Generate xdotool commands based on information about the
+    # event type, file type, and whether the file has changed.
     local window_id=${1:?"Fail. We expect a window ID."}
     local base_url=${2}
+    local file_type
+    local file_status
+    local prev_file_name
 
     while IFS=',' read -r timestamp event_type dir_path file_name
     do
-        # Emit xdotool commands based on the event / filename combination
-        case "${event_type}:${file_name}" in
-            MODIFY\:*.html )
-                # Reload when any content file is modified
+        file_type="${file_name#*\.}"
+
+        file_status=$(
+            if [[ ${file_name} == ${prev_file_name} ]]
+            then printf "%s" "SAMEFILE"
+            else printf "%s" "NEWFILE"
+            fi
+                   )
+
+        # First catch "content" pages, which require special casing.
+        # At last, catch all non-content pages and do the only sane
+        # thing for anything done to those pages; viz. reload the site.
+        case "${event_type}:${file_type}:${file_status}" in
+            # RELOAD
+            # - When any content file is modified
+            # - When any non-current content file is deleted
+            #   (because that may affect the current page)
+            MODIFY:html:SAMEFILE ) ;& # catch vim edits
+            CLOSE_WRITE:CLOSE:html:SAMEFILE ) ;& # catch emacs edits
+            DELETE:html:NEWFILE )
                 __shite_xdo_cmd_browser_refresh ${window_id}
                 ;;
-            CREATE|MOVED_TO\:*.html )
-                # GOTO newly-created or renamed content file
-                __shite_xdo_cmd_goto_url ${window_id} "${base_url:-file://${dir_path%\/}}/${file_name}"
+            # GOTO - NAVIGATE
+            # - Newly-created content file, or
+            # - Moved/renamed content file
+            MODIFY:html:NEWFILE ) ;& # vim new file
+            CLOSE_WRITE:CLOSE:html:NEWFILE ) ;& # emacs new file
+            CREATE:html:* ) ;&
+            MOVED_TO:html:* )
+                __shite_xdo_cmd_goto_url \
+                    ${window_id} \
+                    "${base_url:-file://${dir_path%\/}}/${file_name}"
                 ;;
-            DELETE\:*.html )
-                # Fall back to home page when content file is deleted
-                __shite_xdo_cmd_goto_url ${window_id} "${base_url:-file://${dir_path%\/}}"
+            # GOTO - FALLBACK
+            # - home page when the current content file is deleted
+            DELETE:html:SAMEFILE )
+                __shite_xdo_cmd_goto_url \
+                    ${window_id} \
+                    "${base_url:-file://${dir_path%\/}}"
                 ;;
+
+            # RELOAD page for any action on non-content pages,
+            # presumably static assets.
             * )
-                # Reload page for any action on non-content pages (presumably static assets)
                 __shite_xdo_cmd_browser_refresh ${window_id}
                 ;;
         esac
+
+        # Remember the file for the next cycle
+        prev_file_name=${file_name}
     done
 }
 
 __shite_xdo_cmd_exec() {
-    stdbuf -oL grep -v '^$' | xdotool -
+    local cmd=$(
+        if [[ ${SHITE_DEBUG} == "debug" ]]
+        then "cat"
+        else "xdotool"
+        fi
+          )
+    stdbuf -oL grep -v '^$' | $cmd -
 }
 
 __shite_xdo_cmd_exec_debug_log() {
@@ -131,6 +173,7 @@ __shite_xdo_cmd_exec_debug_log() {
 }
 
 shite_hotreload() {
+    # Maybe improve with getopts later
     local watch_dir=${1:?"Fail. Please specify a directory to watch"}
     local tab_name=${2:?"Fail. We want to target a single specific tab only."}
     local browser_name=${3:-"Mozilla Firefox"}
@@ -140,7 +183,9 @@ shite_hotreload() {
     local window_id=$(xdotool search --onlyvisible --name "${tab_name}.*${browser_name}$")
 
     # Run pipeline
-    __shite_detect_changes ${watch_dir} |
+    # - Events of interest 'create,modify,close_write,moved_to,delete'
+    __shite_detect_changes \
+        ${watch_dir} 'create,modify,close_write,moved_to,delete' |
         __shite_distinct_events |
         __shite_xdo_cmd_exec_debug_log |
         __shite_xdo_cmd_gen ${window_id} ${base_url} |
@@ -148,4 +193,8 @@ shite_hotreload() {
         __shite_xdo_cmd_exec
 }
 
-shite_hotreload "./public" 'A static site'
+__shite_debug_run() {
+    SHITE_DEBUG="debug" shite_hotreload \
+               "./public" 'A static' \
+               > /dev/null
+}

--- a/bin/hotreload.sh
+++ b/bin/hotreload.sh
@@ -47,16 +47,16 @@
 
 __shite_detect_changes() {
     # Continuously monitor the target directory for file CRUD events
-    # Emit a CSV record of UNIX_EPOCH_SECONDS,EVENT_TYPE,FILE_PATH
-    local dir_path="${1:-$(pwd)/public}"
-    local file_types="${2:-'html,js,css'}"
+    # Emit a CSV record of UNIX_EPOCH_SECONDS,EVENT_TYPE,DIR_PATH,FILE_NAME
+    local watch_dir="$(realpath -e ${1:-$(pwd)})"
+    local watch_events=${2:-'create,modify,delete,moved_to'}
 
     # WATCH A DIRECTORY
     inotifywait -m -r --exclude '/\.git/|/\.#|/#|.*(swp|swx|\~)$' \
                 --timefmt "%s" \
-                --format '%T,%:e,%w%f' \
-                -e 'create,modify,delete,moved_to' \
-                ${dir_path} |
+                --format '%T,%:e,%w,%f' \
+                -e ${watch_events} \
+                ${watch_dir} |
         # INCLUDE FILES
         # We have to grep, but a new version of inotifywait has an 'include'
         # option, which should obviate grep. So says Stackoverflow. Also we
@@ -77,83 +77,75 @@ __shite_distinct_events() {
     stdbuf -oL awk 'BEGIN { FS = "," } {if(!seen[$0]++ && seen[$1]++) print}'
 }
 
-__shite_test_actions() {
-    cp -f public/index.html public/deleteme.html
-    echo "foo" >> public/deleteme.html
-    mv public/deleteme.html public/deleteme2.html
-    rm public/deleteme2.html
-    # Should produce these "distinct" events:
-    # 1652008576,MODIFY,/home/adi/src/github/adityaathalye/shite/public/deleteme.html
-    # 1652008576,MOVED_TO,/home/adi/src/github/adityaathalye/shite/public/deleteme2.html
-    # 1652008576,DELETE,/home/adi/src/github/adityaathalye/shite/public/deleteme2.html
+__shite_xdo_cmd_browser_refresh() {
+    local window_id=${1:?"Fail. We expect window ID to be set in scope."}
+
+    printf "%s\n" \
+           "key --window ${window_id} --clearmodifiers 'F5'"
 }
 
-__shite_test_events() {
-    cat <<EOF
-1651991204,CREATE,/home/adi/src/github/adityaathalye/shite/public/deleteme.html
-1651991204,MODIFY,/home/adi/src/github/adityaathalye/shite/public/deleteme.html
-1651991204,MODIFY,/home/adi/src/github/adityaathalye/shite/public/deleteme.html
-1651991204,MOVED_TO,/home/adi/src/github/adityaathalye/shite/public/deleteme2.html
-1651991204,DELETE,/home/adi/src/github/adityaathalye/shite/public/deleteme2.html
-1651991221,CREATE,/home/adi/src/github/adityaathalye/shite/public/deleteme.html
-1651991221,MODIFY,/home/adi/src/github/adityaathalye/shite/public/deleteme.html
-1651991221,MODIFY,/home/adi/src/github/adityaathalye/shite/public/deleteme.html
-EOF
+__shite_xdo_cmd_goto_url() {
+    local window_id=${1}
+    local url=${2}
+
+    printf "%s\n" \
+           "key --window ${window_id} --clearmodifiers 'ctrl+l'" \
+           "type --window ${window_id} --clearmodifiers --delay 1 ${url}" \
+           "key --window ${window_id} --clearmodifiers 'Return'"
 }
 
+__shite_xdo_cmd_gen() {
+    local window_id=${1:?"Fail. We expect a window ID."}
+    local base_url=${2}
 
-__shite_event_cmd() {
-    # Write-ahead log of event_type data, and commands to execute
-    while IFS=',' read -r timestamp event_type filepath
+    while IFS=',' read -r timestamp event_type dir_path file_name
     do
-        case ${event_type} in
-            MODIFY )
-                echo "${event_type} implies Reload page ${filepath}"
+        # Emit xdotool commands based on the event / filename combination
+        case "${event_type}:${file_name}" in
+            MODIFY\:*.html )
+                # Reload when any content file is modified
+                __shite_xdo_cmd_browser_refresh ${window_id}
                 ;;
-            CREATE|MOVED_TO )
-                echo "${event_type} implies Goto new page ${filepath}"
+            CREATE|MOVED_TO\:*.html )
+                # GOTO newly-created or renamed content file
+                __shite_xdo_cmd_goto_url ${window_id} "${base_url:-file://${dir_path%\/}}/${file_name}"
                 ;;
-            DELETE )
-                echo "${event_type} implies Goto home page ${filepath}"
+            DELETE\:*.html )
+                # Fall back to home page when content file is deleted
+                __shite_xdo_cmd_goto_url ${window_id} "${base_url:-file://${dir_path%\/}}"
                 ;;
             * )
-                echo "${event_type} implies No-op ${filepath}"
+                # Reload page for any action on non-content pages (presumably static assets)
+                __shite_xdo_cmd_browser_refresh ${window_id}
                 ;;
         esac
     done
 }
 
-__shite_xdo_cmd_get_window() {
-    local tab_name=${1:?"Fail. We want to target a single specific tab only."}
-    local browser_name=${2:-"Mozilla Firefox"}
-
-    printf "%s\n" \
-           "search --onlyvisible --name \"${tab_name}.*${browser_name}$\""
-}
-
-__shite_xdo_cmd_browser_refresh() {
-    local window_id=${1:?"Fail. We expect window ID to be set in scope."}
-    printf "%s\n" \
-           "key_path --window ${window_id} --clearmodifiers 'F5'"
-}
-
-__shite_xdo_cmd_goto_url() {
-    local window_id=${1:?"Fail. We expect window ID to be set in scope."}
-    local url=${2:-"http://localhost:1313"}
-    printf "%s\n" \
-           "key_path --window ${window_id} --clearmodifiers 'ctrl+l'" \
-           "type --window ${window_id} --clearmodifiers --delay 1 \"${url}\"" \
-           "key_path --window ${window_id} --clearmodifiers 'Return'"
-}
-
 __shite_xdo_cmd_exec() {
-    # Presumably receives legal xdotool commands at stdin.
-    # Empty lines imply no-op.
-    local command_fn=${1:?"Fail. We expect a command function."}
-    shift
-    local command_fn_args="${@}"
-
-    ${command_fn} "${command_fn_args}" |
-        grep -v '^$' |
-        xdotool -
+    stdbuf -oL grep -v '^$' | xdotool -
 }
+
+__shite_xdo_cmd_exec_debug_log() {
+    tee >(1>&2 cat -)
+}
+
+shite_hotreload() {
+    local watch_dir=${1:?"Fail. Please specify a directory to watch"}
+    local tab_name=${2:?"Fail. We want to target a single specific tab only."}
+    local browser_name=${3:-"Mozilla Firefox"}
+    local base_url=${4:-""}
+
+    # Lookup window ID
+    local window_id=$(xdotool search --onlyvisible --name "${tab_name}.*${browser_name}$")
+
+    # Run pipeline
+    __shite_detect_changes ${watch_dir} |
+        __shite_distinct_events |
+        __shite_xdo_cmd_exec_debug_log |
+        __shite_xdo_cmd_gen ${window_id} ${base_url} |
+        __shite_xdo_cmd_exec_debug_log |
+        __shite_xdo_cmd_exec
+}
+
+shite_hotreload "./public" 'A static site'

--- a/bin/hotreload.sh
+++ b/bin/hotreload.sh
@@ -9,8 +9,10 @@
 # Because what could be hotter than hitting f5 for the target tab,
 # in the target browser?
 #
+# While inotify-refresh tries to _periodically_ refresh a set of browser, we
+# want to be more eager. We want page events to trigger refreshes and GOTOs.
+#
 # If this hot reload is not hot enough, there is Emacs impatient-mode.
-
 
 # "Dev-ing/Drafting" time setup/Teardown scenario:
 #
@@ -23,6 +25,11 @@
 
 # Hot reload scenarios:
 #
+# We want to define distinct reload scenarios: Mutually exclusive, collectively
+# exhaustive buckets into which we can map file events we want to monitor. If we
+# do this, then we can model updates as a write-ahead-log. Punch events through
+# an analysis pipeline and associate them with the exact-match scenario.
+#
 # Refresh current tab when
 # - static asset create, modify, move, delete
 #
@@ -33,32 +40,120 @@
 # - current page content modified
 # - any content page moved or created or modified
 
-
-__shite_refresh_browser_tab() {
-    local browser_name=${1:-"firefox"}
-    local tab_name=${2:-'*'}
-
-    xdotool search --onlyvisible --name "${tab_name}.*${browser_name}$" \
-            key --clearmodifiers --window %@ 'F5'
-}
+# Hot reload behaviour:
+# Since we are emulating user behaviour, we can race with the user, e.g. when
+# switching to the browser window. If the time gap is minimal, this should
+# not be too annoying.
 
 __shite_detect_changes() {
-    local dir_path="${1:-.}"
+    # Continuously monitor the target directory for file CRUD events
+    # Emit a CSV record of UNIX_EPOCH_SECONDS,EVENT_TYPE,FILE_PATH
+    local dir_path="${1:-$(pwd)/public}"
+    local file_types="${2:-'html,js,css'}"
 
-    inotifywait -m -r --exclude '/\.git/|/\.#|/#' \
-                --format '%e %w%f' \
-                -e 'modify,moved_to,moved_from,move,create,delete' \
-                ${dir_path}
+    # WATCH A DIRECTORY
+    inotifywait -m -r --exclude '/\.git/|/\.#|/#|.*(swp|swx|\~)$' \
+                --timefmt "%s" \
+                --format '%T,%:e,%w%f' \
+                -e 'create,modify,delete,moved_to' \
+                ${dir_path} |
+        # INCLUDE FILES
+        # We have to grep, but a new version of inotifywait has an 'include'
+        # option, which should obviate grep. So says Stackoverflow. Also we
+        # must prevent grep stdio buffering, else things don't stream down-pipe.
+        # Bah. https://www.perkin.org.uk/posts/how-to-fix-stdio-buffering.html
+        stdbuf -oL grep -E -e "(html|js|css)$"
 }
 
-__shite_is_reload_page_event() {
-    # truthy/falsey
-    # return the event as-is /when/ it implies reload
-    false
+__shite_distinct_events() {
+    # Some editing actions can cause multiple inotify events of the same type for
+    # the same file for a single edit action. e.g. Writing an edit via Vim causes
+    # the sequence CREATE, MODIFIED, MODIFIED.
+    #
+    # We want to ensure we dispatch a hotreload action only on the "final result"
+    # of any single action on a file. For our purpose, this would be the last
+    # event of any contiguous sequence of inotify events on the same file.
+
+    stdbuf -oL awk 'BEGIN { FS = "," } {if(!seen[$0]++ && seen[$1]++) print}'
 }
 
-__shite_is_goto_page_event() {
-    # truthy/falsey
-    # return the event as-is /when/ it implies navigate to page
-    false
+__shite_test_actions() {
+    cp -f public/index.html public/deleteme.html
+    echo "foo" >> public/deleteme.html
+    mv public/deleteme.html public/deleteme2.html
+    rm public/deleteme2.html
+    # Should produce these "distinct" events:
+    # 1652008576,MODIFY,/home/adi/src/github/adityaathalye/shite/public/deleteme.html
+    # 1652008576,MOVED_TO,/home/adi/src/github/adityaathalye/shite/public/deleteme2.html
+    # 1652008576,DELETE,/home/adi/src/github/adityaathalye/shite/public/deleteme2.html
+}
+
+__shite_test_events() {
+    cat <<EOF
+1651991204,CREATE,/home/adi/src/github/adityaathalye/shite/public/deleteme.html
+1651991204,MODIFY,/home/adi/src/github/adityaathalye/shite/public/deleteme.html
+1651991204,MODIFY,/home/adi/src/github/adityaathalye/shite/public/deleteme.html
+1651991204,MOVED_TO,/home/adi/src/github/adityaathalye/shite/public/deleteme2.html
+1651991204,DELETE,/home/adi/src/github/adityaathalye/shite/public/deleteme2.html
+1651991221,CREATE,/home/adi/src/github/adityaathalye/shite/public/deleteme.html
+1651991221,MODIFY,/home/adi/src/github/adityaathalye/shite/public/deleteme.html
+1651991221,MODIFY,/home/adi/src/github/adityaathalye/shite/public/deleteme.html
+EOF
+}
+
+
+__shite_event_cmd() {
+    # Write-ahead log of event_type data, and commands to execute
+    while IFS=',' read -r timestamp event_type filepath
+    do
+        case ${event_type} in
+            MODIFY )
+                echo "${event_type} implies Reload page ${filepath}"
+                ;;
+            CREATE|MOVED_TO )
+                echo "${event_type} implies Goto new page ${filepath}"
+                ;;
+            DELETE )
+                echo "${event_type} implies Goto home page ${filepath}"
+                ;;
+            * )
+                echo "${event_type} implies No-op ${filepath}"
+                ;;
+        esac
+    done
+}
+
+__shite_xdo_cmd_get_window() {
+    local tab_name=${1:?"Fail. We want to target a single specific tab only."}
+    local browser_name=${2:-"Mozilla Firefox"}
+
+    printf "%s\n" \
+           "search --onlyvisible --name \"${tab_name}.*${browser_name}$\""
+}
+
+__shite_xdo_cmd_browser_refresh() {
+    local window_id=${1:?"Fail. We expect window ID to be set in scope."}
+    printf "%s\n" \
+           "key_path --window ${window_id} --clearmodifiers 'F5'"
+}
+
+__shite_xdo_cmd_goto_url() {
+    local window_id=${1:?"Fail. We expect window ID to be set in scope."}
+    local url=${2:-"http://localhost:1313"}
+    printf "%s\n" \
+           "key_path --window ${window_id} --clearmodifiers 'ctrl+l'" \
+           "type --window ${window_id} --clearmodifiers --delay 1 \"${url}\"" \
+           "key_path --window ${window_id} --clearmodifiers 'Return'"
+}
+
+__shite_xdo_cmd_exec() {
+    # Presumably receives legal xdotool commands at stdin.
+    # Empty lines imply no-op.
+    local command_fn=${1:?"Fail. We expect a command function."}
+    shift
+    local command_fn_args="${@}"
+
+    ${command_fn} "${command_fn_args}" |
+        grep -v '^$' |
+        xdotool -
 }

--- a/bin/hotreload_test.sh
+++ b/bin/hotreload_test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+__shite_test_actions() {
+    cp -f public/index.html public/deleteme.html
+    echo "foo" >> public/deleteme.html
+    mv public/deleteme.html public/deleteme2.html
+    rm public/deleteme2.html
+    # Should produce these "distinct" events:
+    # 1652008576,MODIFY,/home/adi/src/github/adityaathalye/shite/public/deleteme.html
+    # 1652008576,MOVED_TO,/home/adi/src/github/adityaathalye/shite/public/deleteme2.html
+    # 1652008576,DELETE,/home/adi/src/github/adityaathalye/shite/public/deleteme2.html
+}
+
+__shite_test_events() {
+    cat <<EOF
+1651991204,CREATE,/home/adi/src/github/adityaathalye/shite/public/,deleteme.html
+1651991204,MODIFY,/home/adi/src/github/adityaathalye/shite/public/,deleteme.html
+1651991204,MODIFY,/home/adi/src/github/adityaathalye/shite/public/,deleteme.html
+1651991204,MOVED_FROM,/home/adi/src/github/adityaathalye/shite/public/,deleteme.html
+1651991204,MOVED_TO,/home/adi/src/github/adityaathalye/shite/public/,deleteme2.html
+1651991204,DELETE,/home/adi/src/github/adityaathalye/shite/public/,deleteme2.html
+1651991221,CREATE,/home/adi/src/github/adityaathalye/shite/public/,deleteme.html
+1651991221,MODIFY,/home/adi/src/github/adityaathalye/shite/public/,deleteme.html
+1651991221,MODIFY,/home/adi/src/github/adityaathalye/shite/public/,deleteme.html
+1651991222,MODIFY,/home/adi/src/github/adityaathalye/shite/public/,static/foo.css
+1651991222,MOVED_FROM,/home/adi/src/github/adityaathalye/shite/public/,static/foo.css
+1651991222,MOVED_FROM,/home/adi/src/github/adityaathalye/shite/public/,static/foo2.css
+1651991223,CREATE,/home/adi/src/github/adityaathalye/shite/public/,static/bar.js
+1651991223,MODIFY,/home/adi/src/github/adityaathalye/shite/public/,static/bar.js
+1651991223,DELETE,/home/adi/src/github/adityaathalye/shite/public/,static/bar.js
+EOF
+}

--- a/bin/rss.sh
+++ b/bin/rss.sh
@@ -1,0 +1,36 @@
+# Add RSS feed.
+
+shite_rss_items() {
+    # Given an input stream of metadata (e.g. JSON), return XML
+    # for a collection of RSS feed items
+    while read shite_post_meta
+    do
+        cat <<EOF
+<item>
+  <title>${shite_data[title]}</title>
+  <link>${shite_data[title]}</link>
+  <link>$(shite_data_get link ${shite_post_meta})</link>
+  <description>$(shite_data_get description ${shite_post_meta})</description>
+</item>
+EOF
+    done
+}
+
+shite_rss_feed() {
+    # pinched from https://www.xul.fr/en-xml-rss.html
+    <<EOF
+<?xml version="1.0" ?>
+<rss version="2.0">
+<channel>
+  <title>$(shite_data_get title)</title>
+  <link>$(shite_data_get url)</link>
+  <description>$(shite_data_get description)</description>
+  <image>
+      <url>$(shite_data_get icon)</url>
+      <link>$(shite_data_get homeurl)</link>
+  </image>
+  $(cat -)
+</channel>
+</rss>
+EOF
+}


### PR DESCRIPTION
Because, we want it, and we want it NOW.

Being entirely spoiled by Clojure/Lisp/Spreadsheet style insta-gratifying live
interactive workflows, I want hot reload and hot navigate in shite-making too.

But there does not seem to exist a standalone live web development server / tool
that does not also want me to download half the known Internet as dependencies.
A thing I *extremely* do *not* want to do.

DuckSearch delivered Emacs impatient-mode, which is quite hot, but I don't want
to hardwire this my Emacs. Luckily, it also delivered this exciting brainwave
featuring 'inotify-tools' and 'xdotool':
[github.com/traviscross/inotify-refresh](https://github.com/traviscross/inotify-refresh)

Hot copy!

Because what could be hotter than my computer slammin' that F5 key *for* me? As
if it *knew* what I really wanted deep down in my heart.