### PR TITLE
Generalise file event pipeline to any kind of targeted action

### DIFF
--- a/bin/hotreload.sh
+++ b/bin/hotreload.sh
@@ -281,10 +281,10 @@ shite_hotreload() {
         __shite_distinct_events |
         # Process any change to content files (org, md etc.)
         tee >(__shite_select_file_events "content" |
-                  __shite_proc_content_events) |
+                  __shite_proc_content_events > /dev/null) |
         # Process any change to static files (css, js, images etc.)
         tee >(__shite_select_file_events "static" |
-                  __shite_proc_static_events) |
+                  __shite_proc_static_events > /dev/null) |
         # Perform hot-reload actions only against changes to public files
         tee >(__shite_select_file_events "public" |
                   __shite_xdo_cmd_gen ${window_id} ${base_url} |

--- a/bin/hotreload.sh
+++ b/bin/hotreload.sh
@@ -89,7 +89,7 @@ __shite_detect_changes() {
 # EVENT FILTERS
 # ##################################################
 
-__shite_distinct_events() {
+__shite_events_dedupe() {
     # Some editing actions can cause multiple inotify events of the same type for
     # the same file for a single edit action. e.g. Writing an edit via Vim causes
     # the sequence CREATE, MODIFIED, MODIFIED. Pulling up the helm minibuffer in
@@ -278,7 +278,7 @@ shite_hotreload() {
     __shite_detect_changes \
         ${watch_dir} 'create,modify,close_write,moved_to,delete' |
         # Deduplicate file events
-        __shite_distinct_events |
+        __shite_events_dedupe |
         # Process any change to content files (org, md etc.)
         tee >(__shite_select_file_events "content" |
                   __shite_proc_content_events > /dev/null) |
@@ -287,6 +287,7 @@ shite_hotreload() {
                   __shite_proc_static_events > /dev/null) |
         # Perform hot-reload actions only against changes to public files
         tee >(__shite_select_file_events "public" |
+                  __shite_events_dedupe |
                   __shite_xdo_cmd_gen ${window_id} ${base_url} |
                   __shite_tap_stream |
                   __shite_xdo_cmd_exec)

--- a/bin/hotreload.sh
+++ b/bin/hotreload.sh
@@ -48,6 +48,16 @@
 # c.f https://www.perkin.org.uk/posts/how-to-fix-stdio-buffering.html
 # ##################################################
 
+__to_stderr() {
+    # Ref: I/O Redirection: http://tldp.org/LDP/abs/html/io-redirection.html
+    if [[ ${SHITE_DEBUG} == "debug" ]]
+    then 1>&2 printf "%s\n" "$(date --iso-8601=seconds) $@"
+    fi
+}
+
+__log_info() {
+    __to_stderr "$(echo "INFO $0 $@")"
+}
 
 __shite_tap_stream() {
     tee >(1>&2 cat -)

--- a/bin/hotreload_test.sh
+++ b/bin/hotreload_test.sh
@@ -13,11 +13,17 @@ __shite_test_actions() {
 
 __shite_test_events() {
     cat <<EOF
+1651991204,CREATE,/home/adi/src/github/adityaathalye/shite/content/,deleteme.org
 1651991204,CREATE,/home/adi/src/github/adityaathalye/shite/public/,deleteme.html
+1651991204,MODIFY,/home/adi/src/github/adityaathalye/shite/content/,deleteme.org
 1651991204,MODIFY,/home/adi/src/github/adityaathalye/shite/public/,deleteme.html
+1651991204,MODIFY,/home/adi/src/github/adityaathalye/shite/content/,deleteme.org
 1651991204,MODIFY,/home/adi/src/github/adityaathalye/shite/public/,deleteme.html
+1651991204,MOVED_FROM,/home/adi/src/github/adityaathalye/shite/content/,deleteme.org
 1651991204,MOVED_FROM,/home/adi/src/github/adityaathalye/shite/public/,deleteme.html
+1651991204,MOVED_TO,/home/adi/src/github/adityaathalye/shite/content/,deleteme2.org
 1651991204,MOVED_TO,/home/adi/src/github/adityaathalye/shite/public/,deleteme2.html
+1651991204,DELETE,/home/adi/src/github/adityaathalye/shite/content/,deleteme2.org
 1651991204,DELETE,/home/adi/src/github/adityaathalye/shite/public/,deleteme2.html
 1651991221,CREATE,/home/adi/src/github/adityaathalye/shite/public/,deleteme.html
 1651991221,MODIFY,/home/adi/src/github/adityaathalye/shite/public/,deleteme.html


### PR DESCRIPTION
for a given event.

This could be compile org-mode file to html, build a static asset,
copy files to public etc. "Targeting" can simply be grep filters.

The approach follows an `awk`-like /pattern/ expression design. Thus,
of course, `awk` knowers will be able to write a cleaner, performant
version. But we have good enough performance for now, and we only
remember enough `awk` to be dangerous. So this is fine.